### PR TITLE
get_stats only when map changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The framework, along with some initial reinforcement learning results, is covere
 ```
 @inproceedings{khalifa2020pcgrl,
   title={PCGRL: Procedural Content Generation via Reinforcement Learning},
-  author={Khalifa, Ahmed and Bontrager, Philip and Erele, Sam and Togelius, Julian},
+  author={Khalifa, Ahmed and Bontrager, Philip and Earle, Sam and Togelius, Julian},
   booktitle={},
   year={2020},
   organization={}

--- a/gym_pcgrl/envs/pcgrl_env.py
+++ b/gym_pcgrl/envs/pcgrl_env.py
@@ -66,7 +66,7 @@ class PcgrlEnv(gym.Env):
         self._rep.reset(self._prob._width, self._prob._height, get_int_prob(self._prob._prob, self._prob.get_tile_types()))
         self._rep_stats = self._prob.get_stats(get_string_map(self._rep._map, self._prob.get_tile_types()))
         self._heatmap = np.zeros((self._prob._height, self._prob._width))
-        
+
         observation = self._rep.get_observation()
         observation["heatmap"] = self._heatmap.copy()
         return observation
@@ -132,7 +132,7 @@ class PcgrlEnv(gym.Env):
         if change:
             self._changes += 1
             self._heatmap[y][x] += 1.0
-        self._rep_stats = self._prob.get_stats(get_string_map(self._rep._map, self._prob.get_tile_types()))
+            self._rep_stats = self._prob.get_stats(get_string_map(self._rep._map, self._prob.get_tile_types()))
 
         # calculate the values
         observation = self._rep.get_observation()

--- a/run.py
+++ b/run.py
@@ -79,5 +79,5 @@ if __name__ == '__main__':
     experiment = 'limited_centered'
     n_cpu = 24
     steps = 1e8
-    env = lambda game: wrappers.DefaultImagePCGRLWrapper(game, 28, random_tile=False)
+    env = lambda game: wrappers.CroppedImagePCGRLWrapper(game, 28, random_tile=False)
     main(game, representation, experiment, env, steps, n_cpu)


### PR DESCRIPTION
I don't think we need to call get_stats() if the map has not changed? This at least seems to be true in binary_problem, and results in higher FPS.