### PR TITLE
Readme typo fix. Clarify path-length doscstring.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,6 @@ share/python-wheels/
 *.egg
 MANIFEST
 
-# Tensorboard Logs
-runs/
-
 # Jupyter logs
 .ipynb_checkpoints/
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ conda create --name pcgrl
 conda activate pcgrl
 pip install tensorflow==1.15
 pip install stable-baselines==2.9.0
-cd gym_pcgrl
+pip install gym==0.19
+cd gym-pcgrl
 pip install -e .
 cd ..
 python train.py
@@ -184,7 +185,8 @@ Lastly, you can just install directly without using any virtual environment:
 ```sh
 pip install tensorflow==1.15
 pip install stable-baselines==2.9.0
-cd gym_pcgrl
+pip install gym==0.19
+cd gym-pcgrl
 pip install -e .
 cd ..
 python train.py

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ conda create --name pcgrl
 conda activate pcgrl
 pip install tensorflow==1.15
 pip install stable-baselines==2.9.0
-pip install gym==0.19
 cd gym-pcgrl
 pip install -e .
 cd ..
@@ -185,7 +184,6 @@ Lastly, you can just install directly without using any virtual environment:
 ```sh
 pip install tensorflow==1.15
 pip install stable-baselines==2.9.0
-pip install gym==0.19
 cd gym-pcgrl
 pip install -e .
 cd ..

--- a/gym_pcgrl/envs/helper.py
+++ b/gym_pcgrl/envs/helper.py
@@ -237,7 +237,7 @@ def run_dikjstra(x, y, map, passable_values):
     return dikjstra_map, visited_map
 
 """
-Calculate the longest path on the map
+Calculate the approximate longest shortest path (i.e. all pairs shortest path) on the map.
 
 Parameters:
     map (any[][]): the current map being tested

--- a/runs/.gitignore
+++ b/runs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
- Note that ``calc_longest_path_length`` is approximate all pairs shortest path length. 
- Fix some typos in the Readme, and specify ``gym==0.19`` as an installation requirement as newer versions of gym appear incompatible.
- Create an empty ``runs`` directory, ignoring files within it for git.